### PR TITLE
feat(qol): make chained macro standalone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,42 +57,50 @@ use core::{
 ///
 #[macro_export]
 macro_rules! chained {
-    ($val: expr, $($fn: expr),*) => {
-        Link::new($val)
+    ($val: expr, $($fn: expr),*) => {{
+        use ::chained::Chained;
+        ::chained::Link::new($val)
             $(.chain($fn))*
-    };
-    ($val: expr => $($fn: expr)=>*) => {
-        Link::new($val)
+    }};
+    ($val: expr => $($fn: expr)=>*) => {{
+        use ::chained::Chained;
+        ::chained::Link::new($val)
             $(.chain($fn))*
-    };
-    (=> $val: expr, $($fn: expr),+) => {
+    }};
+    (=> $val: expr, $($fn: expr),+) => {{
+        use ::chained::Chained;
             $val
             $(.chain($fn))+
-    };
-    (=> $val: expr => $($fn: expr)=>+) => {
+    }};
+    (=> $val: expr => $($fn: expr)=>+) => {{
+        use ::chained::Chained;
             $val
             $(.chain($fn))+
-    };
-    (>> $val: expr, $($fn: expr),*) => {
-        Link::new($val)
+    }};
+    (>> $val: expr, $($fn: expr),*) => {{
+        use ::chained::Chained;
+        ::chained::Link::new($val)
             $(.chain($fn))*
             .eval()
-    };
-    (>> $val: expr => $($fn: expr)=>*) => {
-        Link::new($val)
+    }};
+    (>> $val: expr => $($fn: expr)=>*) => {{
+        use ::chained::Chained;
+        ::chained::Link::new($val)
             $(.chain($fn))*
             .eval()
-    };
-    (>>> $val: expr, $($fn: expr),+) => {
+    }};
+    (>>> $val: expr, $($fn: expr),+) => {{
+        use ::chained::Chained;
             $val
             $(.chain($fn))*
             .eval()
-    };
-    (>>> $val: expr => $($fn: expr)=>+) => {
+    }};
+    (>>> $val: expr => $($fn: expr)=>+) => {{
+        use ::chained::Chained;
             $val
             $(.chain($fn))*
             .eval()
-    };
+    }};
 }
 
 /// The trait that is the heart and soul of this crate.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -106,3 +106,20 @@ mod inter_chain {
         assert_eq!(*b, "")
     }
 }
+
+mod standalone_macro {
+    use chained::chained;
+
+    #[test]
+    fn standalone_macro_eager() {
+        let x = chained!(>> 1, |x| x + 1);
+        assert_eq!(x, 2);
+    }
+
+    #[test]
+    fn standalone_macro_lazy() {
+        let x = chained!(1, |x| x + 1);
+        let y = chained!(>>> x, |y| y * 2);
+        assert_eq!(y, 4);
+    }
+}


### PR DESCRIPTION
The macro now works on its own without requiring any additional imports from the library.